### PR TITLE
fix(README): The design guide URL has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ai03's Keyboard PCB guide
 
 * The guide covers everything from installing KiCad to producing the PCB.
-* [Read it here](https://kbwiki.ai03.me/books/pcb-design/chapter/pcb-designer-guide)
+* [Read it here](https://wiki.ai03.com/books/pcb-design/chapter/pcb-designer-guide)
 
 ### Repo contents
 The repository contains the latest version of a PCB built following the guide.


### PR DESCRIPTION
The link in the current readme is pointed to an invalid subdomain of the ai03 website. I tracked down the correct URL and updated it.